### PR TITLE
Chess API Move limitation fix

### DIFF
--- a/Trinity-Microsoft-HoloLens-Project/Assets/Scripts/BoardManager.cs
+++ b/Trinity-Microsoft-HoloLens-Project/Assets/Scripts/BoardManager.cs
@@ -213,7 +213,8 @@ public class BoardManager : MonoBehaviour
         Stream receiveStream;        
         StreamReader readStream;
 
-        request = WebRequest.Create(APIurlBest + test);
+        request = WebRequest.Create(APIurlBest + test + " KQkq - 0 1" + "&showall=1");
+        Debug.Log(APIurlBest + test + "KQkq - 0 1" + "&showall=1");
         request.Method = "GET";
         response = await request.GetResponseAsync();
         receiveStream = response.GetResponseStream();


### PR DESCRIPTION
Now allows more than a limited number of moves